### PR TITLE
Fixed issues with latest redis package

### DIFF
--- a/redisfs/redis_file.py
+++ b/redisfs/redis_file.py
@@ -18,7 +18,7 @@ class RFile(object):
         dir = os.path.dirname(self.path)
 
         # Make sure folder exists.
-        t = self.conn.type(dir)
+        t = self.conn.type(dir).decode("utf-8")
         if t == "set":
             from .redis_folder import RFolder
             return RFolder(dir, self.conn)

--- a/redisfs/redis_folder.py
+++ b/redisfs/redis_folder.py
@@ -45,7 +45,7 @@ class RFolder(object):
                     continue
 
         # Sort content.
-        content.sort(key=lambda x: x.Name, reverse=True)
+        content.sort(key=lambda x: x.Name(), reverse=True)
         return content
 
     def AddItem(self, item):

--- a/redisfs/redis_folder.py
+++ b/redisfs/redis_folder.py
@@ -19,7 +19,7 @@ class RFolder(object):
         dir = os.path.dirname(self.path)
 
         # Make sure folder exists.
-        t = self.conn.type(dir)
+        t = self.conn.type(dir).decode("utf-8")
         if t == "set":
             return RFolder(dir, self.conn)
         else:
@@ -30,8 +30,9 @@ class RFolder(object):
         content = []
         members = self.conn.smembers(self.path)
         for member in members:
+            member = member.decode("utf-8")
             member_full_path = os.path.join(self.path, member)
-            t = self.conn.type(member_full_path)
+            t = self.conn.type(member_full_path).decode("utf-8")
             if t == "string":
                 content.append(RFile(member_full_path, self.conn))
             elif t == "set":

--- a/redisfs/redis_fs.py
+++ b/redisfs/redis_fs.py
@@ -49,7 +49,7 @@ class RFS(object):
 
     def GetFolder(self, path):
         # Make sure folder exists.
-        t = self.conn.type(path)
+        t = self.conn.type(path).decode("utf-8")
         if t == "set":
             return RFolder(path, self.conn)
         else:
@@ -57,7 +57,7 @@ class RFS(object):
 
     def GetFile(self, path):
         # Make sure file exists.
-        t = self.conn.type(path)
+        t = self.conn.type(path).decode("utf-8")
         if t == "string":
             return RFile(path, self.conn)
         else:
@@ -65,7 +65,7 @@ class RFS(object):
 
     def GetItem(self, path):
         # Look up path and its type.
-        t = self.conn.type(path)
+        t = self.conn.type(path).decode("utf-8")
         if t == "set":
             return RFolder(path, self.conn)
         elif t == "string":


### PR DESCRIPTION
The current version of the Python [redis](https://pypi.org/project/redis/) package returns a `byte` instead of `str` for key types. I've fixed that by decoding the string using `.decode("utf-8")`.

Additionally to that, parentheses were missing in `.Name()` while sorting the list of directory items.